### PR TITLE
Type error: Route "app/api/auth/[...nextauth]/route.ts" does not matc…

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -5,7 +5,7 @@ import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcrypt";
 
-export const authOptions: NextAuthOptions = {
+const authOptions: NextAuthOptions = {
   //prismaを使うための設定
   adapter: PrismaAdapter(prisma),
   //認証プロバイダー


### PR DESCRIPTION
…h the required types of a Next.js Route.

  "authOptions" is not a valid Route export field.
Error: Command "npm run build" exited with 1のエラー解消